### PR TITLE
Speed up program execution by 4 seconds (clearing serial input buffer on initialize())

### DIFF
--- a/mpy_utils/replcontrol.py
+++ b/mpy_utils/replcontrol.py
@@ -23,7 +23,7 @@ class ReplControl(object):
     def initialize(self):
         # break, break, reboot, raw mode
         self.port.write(b"\x03\x03\x01");
-        while (self.port.read(100)): pass
+        self.port.reset_input_buffer()
 
     def reset(self):
         self.port.write(b"\x02\x03\x03\x04")


### PR DESCRIPTION
On ReplControl.initialise(), empty serial input buffer with reset_input_buffer() rather than a long busy-wait. This reduces execution time by 4 seconds