### PR TITLE
Support communication via stdin/stderr rather than serial port

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,5 @@ This will hopefully prevent me from ever having to think about source code forma
 * [Umut Karcı](https://github.com/Cediddi)
 * [Eric Poulsen](https://github.com/MrSurly)
 * [Jeff Gough](https://github.com/jeffmakes)
+* [Stephen Thirlwall](https://github.com/sdt)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@ Utility programs for Micropython ...
 
 [This package is also available through PyPI](https://pypi.python.org/pypi/mpy-utils/)
 
+## Using serial ports directly
+
+All four utilities by default will connect directly to /dev/ttyUSB0 at 115200 baud.
+
+These can be overridden with the `-port` and `--baud` parameters.
+
+## Using serial ports attached to stdin/stdout
+
+[picocom](https://github.com/npat-efault/picocom) is a terminal emulator program that allows you to specify external file transfer programs. The external program is launched with the serial port attached to stdin and stdout.
+
+The mpy-utils have a `--pipe` option which enables this usage.
+
+eg. The following command will set mpy-sync as the picocom file-send program.
+
+```
+picocom -b 115200 -s "mpy-sync --pipe --reset" /dev/ttyUSB0
+```
+
+From within picocom, hit ctrl-A ctrl-S to initiate file-send mode. Type in the filename to send (tab-completion seems to be available), and hit enter. The file will be sent via mpy-sync, and you'll be returned to picocom.
+
+You can also specify the filenames on the picocom/mpy-sync command-line, and from picocom, just his ctrl-A ctrl-S and enter. No filenames needed.
+
 ## Submitting Pull Requests
 
 Before submitting a pull request, please add yourself to the list of contributors below,

--- a/bin/mpy-fuse
+++ b/bin/mpy-fuse
@@ -4,7 +4,7 @@ import argparse
 import fuse
 import os
 
-from mpy_utils.replcontrol import ReplControl
+from mpy_utils.replcontrol import ReplControl, ReplIOSerial
 from mpy_utils.replfuseops import ReplFuseOps
 
 parser = argparse.ArgumentParser(description="FUSE mount a device using only the REPL")
@@ -30,7 +30,10 @@ except FileExistsError:
     exit(1)
 
 repl_control = ReplControl(
-    port=args.port, baud=args.baud, delay=args.delay, debug=args.debug, reset=args.reset
+    io=ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay),
+    delay=args.delay,
+    debug=args.debug,
+    reset=args.reset,
 )
 
 fuse.FUSE(

--- a/bin/mpy-fuse
+++ b/bin/mpy-fuse
@@ -3,13 +3,17 @@
 import argparse
 import fuse
 import os
+import sys
 
-from mpy_utils.replcontrol import ReplControl, ReplIOSerial
+from mpy_utils.replcontrol import ReplControl, ReplIOFileHandle, ReplIOSerial
 from mpy_utils.replfuseops import ReplFuseOps
 
 parser = argparse.ArgumentParser(description="FUSE mount a device using only the REPL")
 parser.add_argument("--port", default="/dev/ttyUSB0", help="serial port device")
 parser.add_argument("--baud", default=115200, type=int, help="port speed in baud")
+parser.add_argument(
+    "--pipe", action="store_true", help="use stdin/stdout instead of serial port"
+)
 parser.add_argument("--base", default="/", help="base path on device")
 parser.add_argument(
     "--delay", default=100.0, type=float, help="delay between lines (ms)"
@@ -29,16 +33,21 @@ except FileExistsError:
     print("mount_point is not a directory")
     exit(1)
 
+if args.pipe:
+    repl_io = ReplIOFileHandle(infh=sys.stdin, outfh=sys.stdout)
+    # use the inode as the fs identifier - not sure what else to use
+    fsname = "mpy-fuse:%s" % os.fstat(sys.stdin.fileno()).st_ino
+else:
+    repl_io = ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay)
+    fsname = "mpy-fuse:%s" % args.port
+
 repl_control = ReplControl(
-    io=ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay),
-    delay=args.delay,
-    debug=args.debug,
-    reset=args.reset,
+    io=repl_io, delay=args.delay, debug=args.debug, reset=args.reset,
 )
 
 fuse.FUSE(
     operations=ReplFuseOps(repl_control, base_path=args.base),
-    fsname="mpy-fuse:%s" % args.port,
+    fsname=fsname,
     mountpoint=args.mount_point,
     nothreads=True,
     foreground=True,

--- a/bin/mpy-sync
+++ b/bin/mpy-sync
@@ -4,7 +4,7 @@ import time
 import argparse
 import os.path
 
-from mpy_utils.replcontrol import ReplControl
+from mpy_utils.replcontrol import ReplControl, ReplIOSerial
 
 parser = argparse.ArgumentParser(
     description="upload files to a device using only the REPL"
@@ -24,7 +24,10 @@ parser.add_argument("files", nargs="*", type=str)
 args = parser.parse_args()
 
 repl_control = ReplControl(
-    port=args.port, baud=args.baud, delay=args.delay, debug=args.debug, reset=args.reset
+    io=ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay),
+    delay=args.delay,
+    debug=args.debug,
+    reset=args.reset,
 )
 
 repl_control.command("import os")

--- a/bin/mpy-sync
+++ b/bin/mpy-sync
@@ -5,13 +5,16 @@ import argparse
 import os.path
 import sys
 
-from mpy_utils.replcontrol import ReplControl, ReplIOSerial
+from mpy_utils.replcontrol import ReplControl, ReplIOFileHandle, ReplIOSerial
 
 parser = argparse.ArgumentParser(
     description="upload files to a device using only the REPL"
 )
 parser.add_argument("--port", default="/dev/ttyUSB0", help="serial port device")
 parser.add_argument("--baud", default=115200, type=int, help="port speed in baud")
+parser.add_argument(
+    "--pipe", action="store_true", help="use stdin/stdout instead of serial port"
+)
 parser.add_argument(
     "--delay", default=100.0, type=float, help="delay between lines (ms)"
 )
@@ -24,11 +27,13 @@ parser.add_argument(
 parser.add_argument("files", nargs="*", type=str)
 args = parser.parse_args()
 
+if args.pipe:
+    repl_io = ReplIOFileHandle(infh=sys.stdin, outfh=sys.stdout)
+else:
+    repl_io = ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay)
+
 repl_control = ReplControl(
-    io=ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay),
-    delay=args.delay,
-    debug=args.debug,
-    reset=args.reset,
+    io=repl_io, delay=args.delay, debug=args.debug, reset=args.reset,
 )
 
 repl_control.command("import os")

--- a/bin/mpy-sync
+++ b/bin/mpy-sync
@@ -3,6 +3,7 @@
 import time
 import argparse
 import os.path
+import sys
 
 from mpy_utils.replcontrol import ReplControl, ReplIOSerial
 
@@ -49,7 +50,7 @@ def sync_files(files):
 
 
 def copy_file(source, dest):
-    print("copying %s => %s" % (repr(source), repr(dest)))
+    print("copying %s => %s" % (repr(source), repr(dest)), file=sys.stderr)
     fh = open(source, "rb")
     rfh = repl_control.variable("open", "/" + dest, "wb")
     while True:

--- a/bin/mpy-upload
+++ b/bin/mpy-upload
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 import argparse
 import os.path
 
-from mpy_utils.replcontrol import ReplControl
+from mpy_utils.replcontrol import ReplControl, ReplIOSerial
 
 parser = argparse.ArgumentParser(
     description="upload files to a device using only the REPL"
@@ -24,7 +24,10 @@ parser.add_argument("files", nargs="*", type=argparse.FileType("rb"))
 args = parser.parse_args()
 
 repl_control = ReplControl(
-    port=args.port, baud=args.baud, delay=args.delay, debug=args.debug, reset=args.reset
+    io=ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay),
+    delay=args.delay,
+    debug=args.debug,
+    reset=args.reset,
 )
 
 for fh in args.files:

--- a/bin/mpy-upload
+++ b/bin/mpy-upload
@@ -3,14 +3,18 @@
 import time
 import argparse
 import os.path
+import sys
 
-from mpy_utils.replcontrol import ReplControl, ReplIOSerial
+from mpy_utils.replcontrol import ReplControl, ReplIOFileHandle, ReplIOSerial
 
 parser = argparse.ArgumentParser(
     description="upload files to a device using only the REPL"
 )
 parser.add_argument("--port", default="/dev/ttyUSB0", help="serial port device")
 parser.add_argument("--baud", default=115200, type=int, help="port speed in baud")
+parser.add_argument(
+    "--pipe", action="store_true", help="use stdin/stdout instead of serial port"
+)
 parser.add_argument(
     "--delay", default=100.0, type=float, help="delay between lines (ms)"
 )
@@ -23,11 +27,13 @@ parser.add_argument(
 parser.add_argument("files", nargs="*", type=argparse.FileType("rb"))
 args = parser.parse_args()
 
+if args.pipe:
+    repl_io = ReplIOFileHandle(infh=sys.stdin, outfh=sys.stdout)
+else:
+    repl_io = ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay)
+
 repl_control = ReplControl(
-    io=ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay),
-    delay=args.delay,
-    debug=args.debug,
-    reset=args.reset,
+    io=repl_io, delay=args.delay, debug=args.debug, reset=args.reset,
 )
 
 for fh in args.files:

--- a/bin/mpy-watch
+++ b/bin/mpy-watch
@@ -7,6 +7,7 @@ import os
 import re
 import difflib
 import stat
+import sys
 
 from mpy_utils.replcontrol import ReplControl, ReplIOSerial
 
@@ -76,13 +77,13 @@ def sync_files(file_list, file_cache={}):
     if args.delete:
         extra_set = set(file_cache.keys()) - set(x[1] for x in file_list)
         if extra_set:
-            print("initializing ...")
+            log("initializing ...")
             repl_control.initialize()
             repl_control.command("import os")
             initialized = True
 
             for dest_path in extra_set:
-                print("deleting %s" % repr(dest_path))
+                log("deleting %s" % repr(dest_path))
                 repl_control.statement("os.remove", dest_path)
                 del file_cache[dest_path]
 
@@ -97,7 +98,7 @@ def sync_files(file_list, file_cache={}):
             continue
 
         if not initialized:
-            print("initializing ...")
+            log("initializing ...")
             repl_control.initialize()
             repl_control.command("import os")
             initialized = True
@@ -109,7 +110,7 @@ def sync_files(file_list, file_cache={}):
 
             remote_fh = repl_control.variable("open", dest_path, "rb")
             sequence_matcher = difflib.SequenceMatcher(None, cache_text, source_text)
-            print(
+            log(
                 "patching %s => %s (%d bytes, %f ratio)"
                 % (
                     repr(source_path),
@@ -140,7 +141,7 @@ def sync_files(file_list, file_cache={}):
             del remote_fh
 
         else:
-            print(
+            log(
                 "copying %s => %s (%d bytes)"
                 % (repr(source_path), repr(dest_path), len(source_text))
             )
@@ -161,7 +162,7 @@ def sync_files(file_list, file_cache={}):
         file_cache[dest_path] = [source_mtime, source_text]
 
     if initialized and args.reset:
-        print("resetting ...")
+        log("resetting ...")
         repl_control.reset()
 
 
@@ -175,7 +176,11 @@ def delete_files(file_list, dest_dir="/"):
         elif stat.S_ISDIR(dest_stat[0]):
             delete_files(file_list, dest_path)
         elif path_re.match(dest_path) and dest_path not in file_set:
-            print("deleting %s" % dest_path)
+            log("deleting %s" % dest_path)
+
+
+def log(msg):
+    print(msg, file=sys.stderr)
 
 
 if args.download:

--- a/bin/mpy-watch
+++ b/bin/mpy-watch
@@ -9,13 +9,16 @@ import difflib
 import stat
 import sys
 
-from mpy_utils.replcontrol import ReplControl, ReplIOSerial
+from mpy_utils.replcontrol import ReplControl, ReplIOFileHandle, ReplIOSerial
 
 parser = argparse.ArgumentParser(
     description="upload files to a device using only the REPL"
 )
 parser.add_argument("--port", default="/dev/ttyUSB0", help="serial port device")
 parser.add_argument("--baud", default=115200, type=int, help="port speed in baud")
+parser.add_argument(
+    "--pipe", action="store_true", help="use stdin/stdout instead of serial port"
+)
 parser.add_argument(
     "--delay", default=100.0, type=float, help="delay between lines (ms)"
 )
@@ -35,12 +38,13 @@ parser.add_argument("source_dir", type=str, default=".")
 parser.add_argument("dest_dir", type=str, default="/", nargs="?")
 args = parser.parse_args()
 
+if args.pipe:
+    repl_io = ReplIOFileHandle(infh=sys.stdin, outfh=sys.stdout)
+else:
+    repl_io = ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay)
 
 repl_control = ReplControl(
-    io=ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay),
-    delay=args.delay,
-    debug=args.debug,
-    reset=args.reset,
+    io=repl_io, delay=args.delay, debug=args.debug, reset=args.reset,
 )
 
 

--- a/bin/mpy-watch
+++ b/bin/mpy-watch
@@ -8,7 +8,7 @@ import re
 import difflib
 import stat
 
-from mpy_utils.replcontrol import ReplControl
+from mpy_utils.replcontrol import ReplControl, ReplIOSerial
 
 parser = argparse.ArgumentParser(
     description="upload files to a device using only the REPL"
@@ -34,9 +34,14 @@ parser.add_argument("source_dir", type=str, default=".")
 parser.add_argument("dest_dir", type=str, default="/", nargs="?")
 args = parser.parse_args()
 
+
 repl_control = ReplControl(
-    port=args.port, baud=args.baud, delay=args.delay, debug=args.debug
+    io=ReplIOSerial(port=args.port, baud=args.baud, delay=args.delay),
+    delay=args.delay,
+    debug=args.debug,
+    reset=args.reset,
 )
+
 
 path_re = re.compile(r"(/[^./][^/]*)*\.(py|html?|js|css|png|gif|jpe?g)$")
 

--- a/mpy_utils/replcontrol.py
+++ b/mpy_utils/replcontrol.py
@@ -29,10 +29,8 @@ class ReplIOSerial(object):
 
 
 class ReplControl(object):
-    def __init__(
-        self, port="/dev/ttyUSB0", baud=115200, delay=0, debug=False, reset=True
-    ):
-        self.io = ReplIOSerial(port, baud, delay)
+    def __init__(self, io, delay=0, debug=False, reset=True):
+        self.io = io
         self.buffer = b""
         self.delay = delay
         self.debug = debug

--- a/mpy_utils/replcontrol.py
+++ b/mpy_utils/replcontrol.py
@@ -2,6 +2,7 @@ import serial
 import string
 import atexit
 import time
+import sys
 
 
 class ReplIOSerial(object):
@@ -59,7 +60,7 @@ class ReplControl(object):
                 break
             elif time.time() - start > 3:
                 if self.debug:
-                    print("Forcefully breaking the boot.py")
+                    self.log("Forcefully breaking the boot.py")
                 self.io.writebytes(b"\x03\x03\x01\x04")
             time.sleep(self.delay / 1000.0)
         self.io.flushinput()
@@ -69,7 +70,7 @@ class ReplControl(object):
 
     def command(self, cmd):
         if self.debug:
-            print(">>> %s" % cmd)
+            self.log(">>> %s" % cmd)
         self.io.writebytes(cmd.encode("ASCII") + b"\x04")
         time.sleep(self.delay / 1000.0)
         ret = self.response()
@@ -78,11 +79,11 @@ class ReplControl(object):
         if ret.startswith(b"OK"):
             if err:
                 if self.debug:
-                    print("<<< %s" % err)
+                    self.log("<<< %s" % err)
                 return err
             elif len(ret) > 2:
                 if self.debug:
-                    print("<<< %s" % ret[2:])
+                    self.log("<<< %s" % ret[2:])
                 try:
                     return eval(ret[2:], {"__builtins__": {}}, {})
                 except SyntaxError as e:
@@ -99,6 +100,9 @@ class ReplControl(object):
 
     def variable(self, func, *args):
         return ReplControlVariable(self, func, *args)
+
+    def log(self, msg):
+        print(msg, file=sys.stderr)
 
 
 class ReplControlVariable(object):


### PR DESCRIPTION
My ideal workflow with micropython would be to editing source files in my text editor, with mpy-watch syncing the changes to the microcontroller, but also to have the repl open so that I could manually try out functions or whatever.

Having the repl and mpy-watch connected at the same time isn't really an option, so this is an attempt at a workaround.

[picocom](https://github.com/npat-efault/picocom) has a `--send-cmd` option which is intended for use with a file-send program such as sx or sz. The specified command is spawned with picocom's serial port attached to stdin and stdout.

This PR adds a `--pipe` option to each of the mpy-utils programs, which will use the stdin/stdout filehandles instead of using the serial port directly, allowing these to be spawned from picocom.

eg. `picocom -b 115200 -s "mpy-sync --pipe --reset src/"`

From with picocom, hitting C-a C-s enter will run mpy-sync, and then return to the repl.


The serial port handling code in replcontrol.py has been factored out into a `ReplIOSerial` class, and a `ReplIOFileHandle` class has been added.

All four mpy-utils have been converted. I don't quite see a use-case for spawning mpy-fuse from the repl, but it got added for completeness.

These can be tested directly from the Linux command-line by redirecting the serial device file to both stdin and stdout.

eg. `mpy-watch --pipe --debug < /dev/ttyUSB0 > /dev/ttyUSB0`

All logging and trace messages have been changed to use stderr.