### PR TITLE
Switch FUSE bindings from fusepy to mfusepy

### DIFF
--- a/bin/mpy-fuse
+++ b/bin/mpy-fuse
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
-import fuse
+import mfusepy as fuse
 import os
 import sys
 

--- a/mpy_utils/replfuseops.py
+++ b/mpy_utils/replfuseops.py
@@ -1,7 +1,7 @@
 import errno
 import stat
 import posix
-import fuse
+import mfusepy as fuse
 import os
 
 BUFSIZ = 50

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     license="MIT",
     packages=["mpy_utils"],
     scripts=["bin/mpy-fuse", "bin/mpy-upload", "bin/mpy-download", "bin/mpy-sync", "bin/mpy-watch", "bin/mpy-reset"],
-    install_requires=["fusepy>=3", "pyserial>=3"],
+    install_requires=["mfusepy>=1.1", "pyserial>=3"],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Console",


### PR DESCRIPTION
fusepy has been unmaintained since 2019 and only supports libfuse2, which is being phased out by several distributions. mfusepy is an API-compatible fork that supports both libfuse2 and libfuse3 and is actively maintained.

The migration is a drop-in import rename, no behavioural change.